### PR TITLE
Add CSRF exemptions and adjust cookie settings for dev

### DIFF
--- a/throwin/accounts/rest/views/user.py
+++ b/throwin/accounts/rest/views/user.py
@@ -232,6 +232,7 @@ class StaffDetailForConsumer(generics.RetrieveAPIView):
         return Response(data, status=status.HTTP_200_OK)
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class ConsumerLikeStaffCreateDestroy(generics.GenericAPIView):
 
     def post(self, request, *args, **kwargs):
@@ -304,6 +305,7 @@ class ConsumerLikeStaffCreateDestroy(generics.GenericAPIView):
                 }, status=status.HTTP_400_BAD_REQUEST)
 
 
+@method_decorator(csrf_exempt, name="dispatch")
 class FavoriteStaffList(generics.ListAPIView):
     """
     API endpoint to list all favorite (liked) staff members for the authenticated consumer.

--- a/throwin/throwin/settings/production.py
+++ b/throwin/throwin/settings/production.py
@@ -230,16 +230,16 @@ CSRF_TRUSTED_ORIGINS = [
 CORS_ALLOW_CREDENTIALS = True
 
 CSRF_USE_SESSIONS = True
-CSRF_COOKIE_DOMAIN = "115.127.159.140"
+CSRF_COOKIE_DOMAIN = "localhost:3000"
 
-SESSION_COOKIE_SAMESITE = None
-CSRF_COOKIE_SAMESITE = None
+# SESSION_COOKIE_SAMESITE = None
+# CSRF_COOKIE_SAMESITE = None
 SESSION_COOKIE_SECURE = False   # If not using HTTPS locally
 CSRF_COOKIE_SECURE = False      # If not using HTTPS locally
 
 
-CSRF_COOKIE_HTTPONLY = False  # Allow JS to read CSRF cookies, if needed
-SESSION_COOKIE_HTTPONLY = True  # Keep session cookie secure
+# CSRF_COOKIE_HTTPONLY = False  # Allow JS to read CSRF cookies, if needed
+# SESSION_COOKIE_HTTPONLY = True  # Keep session cookie secure
 # CSRF_COOKIE_DOMAIN = 'core-sm.online'
 
 REST_FRAMEWORK = {


### PR DESCRIPTION
Added `@method_decorator(csrf_exempt)` to specific API views to prevent CSRF checks during development. Updated cookie domain to "localhost:3000" and commented out certain cookie-related settings for local development convenience.