### PR TITLE
Simplify consumer like/unlike functionality for staff.

### DIFF
--- a/throwin/accounts/rest/urls/user.py
+++ b/throwin/accounts/rest/urls/user.py
@@ -8,11 +8,11 @@ from accounts.rest.views.user import (
     EmailChangeRequest,
     EmailChangeRequestVerify,
     StaffDetailForConsumer,
-    ConsumerLikeStaffCreateDestroy,
     FavoriteStaffList,
     Me,
     DeleteUser,
     StaffList,
+    ConsumerLikeStaffToggle,
 )
 
 urlpatterns = [
@@ -48,7 +48,7 @@ urlpatterns = [
     ),
     path(
         "/staff/<uuid:uid>/like",
-        ConsumerLikeStaffCreateDestroy.as_view(),
+        ConsumerLikeStaffToggle.as_view(),
         name="consumer-like-stuff"
     ),
     path(


### PR DESCRIPTION
Replaced `ConsumerLikeStaffCreateDestroy` with `ConsumerLikeStaffToggle` to unify the logic for liking and unliking staff members into a single endpoint. Streamlined the handling for both authenticated and guest users, improving code readability and maintainability.

## Summary by Sourcery

New Features:
- Allow users to toggle their like status for staff members through a single endpoint.